### PR TITLE
Remove https to fix generated .torrents

### DIFF
--- a/_constants.py
+++ b/_constants.py
@@ -1,2 +1,2 @@
 __version__ = "1.4"
-__site_url__ = "https://apollo.rip"
+__site_url__ = "http://apollo.rip"


### PR DESCRIPTION
https is not fully implemented for the tracker so .torrents created using it will not work yet.