### PR TITLE
Separate out site_url and torrent_url into separate variables

### DIFF
--- a/_constants.py
+++ b/_constants.py
@@ -1,2 +1,3 @@
 __version__ = "1.4"
-__site_url__ = "http://apollo.rip"
+__site_url__ = "https://apollo.rip"
+__torrent_url__ = "http://apollo.rip:2095"

--- a/xanaxapi.py
+++ b/xanaxapi.py
@@ -8,7 +8,7 @@ import mechanize
 import HTMLParser
 from cStringIO import StringIO
 
-from _constants import __site_url__
+from _constants import __site_url__, __torrent_url__
 
 headers = {
     'Connection': 'keep-alive',
@@ -78,7 +78,7 @@ class XanaxAPI:
         self.authkey = None
         self.passkey = None
         self.userid = None
-        self.tracker = __site_url__ + ":2095/"
+        self.tracker = __torrent_url__ + "/"
         self.last_request = time.time()
         self.rate_limit = 2.0 # seconds between requests
         self._login()


### PR DESCRIPTION
The site now gets auto upgraded to https while the tracker still doesn't use http.