### PR TITLE
re-add https since http is no longer an option

### DIFF
--- a/_constants.py
+++ b/_constants.py
@@ -1,2 +1,2 @@
 __version__ = "1.4"
-__site_url__ = "http://apollo.rip"
+__site_url__ = "https://apollo.rip"


### PR DESCRIPTION
Keeping http in will cause the client to fail as it cannot handle a 301