### PR TITLE
option to check transcode directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ If you are on a seedbox, or a system without root priviliages, try this:
     $ pip install --user -r requirements.txt
 
 Some seedbox providers (such as seedhost.eu) will not work properly with `--user` as
-they have the system packages overriding the local ones (especially if you're using 
-`requests[security]`). You'll need to create a 
+they have the system packages overriding the local ones (especially if you're using
+`requests[security]`). You'll need to create a
 [virtualenv](https://virtualenv.pypa.io/en/stable/) to use it. This can be accomplished
 as:
 
@@ -70,7 +70,7 @@ Ubuntu you can do this:
 
 On Mac using [homebrew](https://homebrew.sh):
 
-    $ brew install mktorrent flac lame sox    
+    $ brew install mktorrent flac lame sox
 
 If you are on a seedbox and you lack the privilages to install packages,
 you could contact your provider to have these packages installed.
@@ -91,7 +91,7 @@ like this:
 
     [xanax]
     username =
-    password = 
+    password =
     data_dir =
     output_dir =
     torrent_dir =
@@ -100,20 +100,20 @@ like this:
     24bit_behaviour = 0
 
 `username` and `password` are your Apollo.Rip login credentials. Note,
-if either contain a `%`, you need to put an additional `%` before it 
-(so if your password was `a%b`, you need to type `a%%b`).  
-`data_dir` is the directory where your downloads are stored.  
+if either contain a `%`, you need to put an additional `%` before it
+(so if your password was `a%b`, you need to type `a%%b`).
+`data_dir` is the directory where your downloads are stored.
 `output_dir` is the directory where your transcodes will be created. If
-the value is blank, `data_dir` will be used.  
+the value is blank, `data_dir` will be used.
 `torrent_dir` is the directory where torrents should be created (e.g.,
 your watch directory). `formats` is a list of formats that you'd like to
 support (so if you don't want to upload V2, just remove it from this
-list).  
+list).
 `media` is a list of lossless media types you want to consider for
 transcoding. The default value is all Apollo.Rip lossless formats, but if
 you want to transcode only CD and vinyl media, for example, you would
-set this to 'cd, vinyl'.  
-`24bit_behaviour` defines what happens when the program encounters a FLAC 
+set this to 'cd, vinyl'.
+`24bit_behaviour` defines what happens when the program encounters a FLAC
 that it thinks is 24bits. If it is set to '2', every FLAC that has a bits-
 per-sample property of 24 will be silently re-categorized. If it set to '1',
 a prompt will appear. The default is '0' which ignores these occurrences.
@@ -138,10 +138,10 @@ Usage
     usage: xanaxbetter [-h] [-s] [-j THREADS] [--config CONFIG] [--cache CACHE]
                        [-U] [-E] [--version]
                        [release_urls [release_urls ...]]
-    
+
     positional arguments:
       release_urls          the URL where the release is located (default: None)
-    
+
     optional arguments:
       -h, --help            show this help message and exit
       -s, --single          only add one format per release (useful for getting
@@ -153,8 +153,10 @@ Usage
       --cache CACHE         the location of the cache (default:
                             /Users/mpeveler/.xanaxbetter/cache)
       -U, --no-upload       don't upload new torrents (in case you want to do it
-                            manually) (default: False)
       -E, --no-24bit-edit   don't try to edit 24-bit torrents mistakenly labeled
+      -C, --check-dir       check/verify (eventually edit) transcode directory
+                            name before creation (default: False)
+                            manually) (default: False)
                             as 16-bit (default: False)
       --version             show program's version number and exit
 

--- a/transcode.py
+++ b/transcode.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import readline
 
 import mutagen.flac
 
@@ -246,7 +247,7 @@ def get_transcode_dir(flac_dir, output_dir, output_format, resample):
 
     return os.path.join(output_dir, transcode_dir)
 
-def transcode_release(flac_dir, output_dir, output_format, max_threads=None):
+def transcode_release(flac_dir, output_dir, output_format, check_dir=False, max_threads=None):
     '''
     Transcode a FLAC release into another format.
     '''
@@ -272,6 +273,15 @@ def transcode_release(flac_dir, output_dir, output_format, max_threads=None):
     # transcode. Do not change this assumption without considering the
     # consequences!
     transcode_dir = get_transcode_dir(flac_dir, output_dir, output_format, resample)
+    if check_dir:
+        # prompt user with transcode_dir prefilled, only have to hit Enter
+        # if ok but is able to edit if necessary
+        print '\nPress Enter to validate following transcode directory name (after edition if necessary):'
+        readline.set_startup_hook(lambda: readline.insert_text(transcode_dir))
+        try:
+            transcode_dir = raw_input()
+        finally:
+            readline.set_startup_hook()
     if not os.path.exists(transcode_dir):
         os.makedirs(transcode_dir)
     else:

--- a/xanaxbetter
+++ b/xanaxbetter
@@ -63,6 +63,7 @@ def main():
             default=os.path.expanduser('~/.xanaxbetter/cache'))
     parser.add_argument('-U', '--no-upload', action='store_true', help='don\'t upload new torrents (in case you want to do it manually)')
     parser.add_argument('-E', '--no-24bit-edit', action='store_true', help='don\'t try to edit 24-bit torrents mistakenly labeled as 16-bit')
+    parser.add_argument('-C', '--check-dir', action='store_true', help='check/verify (eventually edit) transcode directory name before creation')
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
     args = parser.parse_args()
@@ -114,6 +115,7 @@ def main():
             supported_media = xanaxapi.lossless_media
 
     upload_torrent = not args.no_upload
+    check_dir = args.check_dir
 
     print 'Logging in to %s...' % __site_url__
     api = xanaxapi.XanaxAPI(username, password)
@@ -211,7 +213,7 @@ def main():
                 print 'Adding format %s...' % format,
                 tmpdir = tempfile.mkdtemp()
                 try:
-                    transcode_dir = transcode.transcode_release(flac_dir, output_dir, format, max_threads=args.threads)
+                    transcode_dir = transcode.transcode_release(flac_dir, output_dir, format, check_dir, max_threads=args.threads)
                     new_torrent = transcode.make_torrent(transcode_dir, tmpdir, api.tracker, api.passkey)
                     if upload_torrent:
                         permalink = api.permalink(torrent)


### PR DESCRIPTION
The get_transcode_dir function in transcode.py doesn't always return a correct path, for example keeping the bit depth makes no sense for MP3 transcode. And there still are problems when the album title contains '24' and '96'.

With this option enabled (`-C`), the user is able to verify the correctness of the transcode directory name. For each transcode the script will prompt with the name pre-filled, only need to press Enter for validation after eventual edition.