### PR TITLE
On request error, rethrow the ValueError

### DIFF
--- a/xanaxapi.py
+++ b/xanaxapi.py
@@ -116,8 +116,8 @@ class XanaxAPI:
             if parsed['status'] != 'success':
                 raise RequestException
             return parsed['response']
-        except ValueError:
-            raise RequestException
+        except ValueError as e:
+            raise RequestException(e)
 
     def request_html(self, action, **kwargs):
         while time.time() - self.last_request < self.rate_limit:


### PR DESCRIPTION
This creates a cleaner error message when something goes wrong,
e.g.:

```
Traceback (most recent call last):
  File "./xanaxbetter", line 247, in <module>
    main()
  File "./xanaxbetter", line 131, in main
    api = xanaxapi.XanaxAPI(username, password)
  File "~/xanaxbetter/xanaxapi.py", line 84, in __init__
    self._login()
  File "~/xanaxbetter/xanaxapi.py", line 94, in _login
    accountinfo = self.request('index')
  File "~/xanaxbetter/xanaxapi.py", line 120, in request
    raise RequestException(e)
xanaxapi.RequestException: No JSON object could be decoded
```

Before, only `xanaxapi.RequestException` was printed, now the underlying reason will be displayed.